### PR TITLE
Composer already install the dev packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cd badge-poser
 - Install vendors:
 
 ``` bash
-php composer.phar install --dev
+php composer.phar install
 ```
 
 - This will give you proper results:


### PR DESCRIPTION
One of the latest Composer's update tells that install command installs --dev packages.
If you don't want to install them, then you have to declare --no-dev
