### PR TITLE
Image generation cache problem solved

### DIFF
--- a/src/PUGX/BadgeBundle/Controller/BadgeController.php
+++ b/src/PUGX/BadgeBundle/Controller/BadgeController.php
@@ -146,7 +146,7 @@ class BadgeController extends ContainerAware
      *
      * @return StreamedResponse
      */
-    protected function streamImage($status, $image, $outputFilename)
+    protected function streamImage($status, $image, $outputFilename, $maxage = 3600, $smaxage = 3600)
     {
         $imageCreator = $this->container->get('image_creator');
 
@@ -158,6 +158,11 @@ class BadgeController extends ContainerAware
 
         $response->headers->set('Content-Type', 'image/png');
         $response->headers->set('Content-Disposition', 'inline; filename="'.$outputFilename.'"');
+
+        //adding cache-control as standard annotation fails here
+        $cacheControl = sprintf('public, maxage=%s, s-maxage=%s', $maxage, $smaxage);
+        $response->headers->set('Cache-Control', $cacheControl);
+
         $response->send();
 
         $imageCreator->destroyImage($image);

--- a/src/PUGX/BadgeBundle/Tests/Controller/BadgeControllerTest.php
+++ b/src/PUGX/BadgeBundle/Tests/Controller/BadgeControllerTest.php
@@ -60,6 +60,8 @@ class BadgeControllerTest extends WebTestCase
         $crawler = $client->request('GET', '/pugx/badge-poser/v/unstable.png');
 
         $this->assertTrue($client->getResponse()->isSuccessful());
+        $response = $client->getResponse();
+        $this->assertRegExp('/s-maxage=3600/', $response->headers->get('Cache-Control'));
     }
 
     public function testIfPackageDoesntExist()


### PR DESCRIPTION
StreamRequest::send() called inside streamImage method of BadgeController took the Cache annotation out of the game. Cache-Control headers explicitly added inside the method
