### PR TITLE
added EasterEgg for pugx/badge-poser repository

### DIFF
--- a/src/PUGX/BadgeBundle/Service/EasterEggPackageManager.php
+++ b/src/PUGX/BadgeBundle/Service/EasterEggPackageManager.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PUGX\BadgeBundle\Service;
+
+use PUGX\BadgeBundle\Package\Package;
+
+class EasterEggPackageManager extends PackageManager
+{
+    /**
+     * Get the Type of the Downloads (total, monthly or daily), but if badge-poser it returns randomic numbers.
+     *
+     * @param Package $package
+     * @param string  $type
+     *
+     * @return string
+     */
+    public function getPackageDownloads(Package $package, $type)
+    {
+        $statsType = 'get' . ucfirst($type);
+
+        if ($package && ($download = $package->getDownloads()) && $download instanceof \Packagist\Api\Result\Package\Downloads) {
+
+            if ($package->getName() == 'pugx/badge-poser') {
+                return rand(10, 19) * pow(10, rand(1, 9));
+            }
+
+            return $download->{$statsType}();
+        }
+    }
+}


### PR DESCRIPTION
adding this into parameters.yml

``` yml
package_manager.class: PUGX\BadgeBundle\Service\EasterEggPackageManager
```

the pugx/badge-poser has magic and randomic downloads number :) 
### why?

Because we could remove the symfony example in the homepage, and put badge-poser :+1: 

what do you think? Is easy to enable and disable ... 
