### PR TITLE
Fix bug #102

### DIFF
--- a/src/PUGX/BadgeBundle/Resources/public/js/snippet.js
+++ b/src/PUGX/BadgeBundle/Resources/public/js/snippet.js
@@ -22,13 +22,13 @@ $(document).ready(function(){
         escapeMarkup: function (m) { return m; }
     });
 
-    function packageFormatResult(package) {
-        var markup = "<dt>" + package.id + "</dt><dd>" + package.description + "</dd>";
+    function packageFormatResult(packageInfo) {
+        var markup = "<dt>" + packageInfo.id + "</dt><dd>" + packageInfo.description + "</dd>";
         return markup;
     }
 
-    function packageFormatSelection(package) {
-        return package.id;
+    function packageFormatSelection(packageInfo) {
+        return packageInfo.id;
     }
 
     var lock = function(){


### PR DESCRIPTION
Quoting from here: http://bit.ly/1doSENR 'YUI compressor treats certain JS identifiers (incorrectly) as reserved words and issues this error when a reserved word is used as a formal parameter'
