### PR TITLE
Remove outdated autoloader configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
             "PUGX\\Badge\\": "src/Badge/src/",
             "PUGX\\BadgeBundle\\": "src/PUGX/BadgeBundle/",
             "PUGX\\StatsBundle\\": "src/PUGX/StatsBundle/"
-        },
-        "psr-0": { "PUGX": "src/PUGX/" }
+        }
     },
     "autoload-dev": {
         "psr-4": { "PUGX\\Badge\\": "src/Badge/tests/" }


### PR DESCRIPTION
This PSR-0 configuration will not match any class in the repo anyway, because it looks for files in src/PUGX/PUGX, which does not exist.

Closes #135
