### PR TITLE
Add redirect and alias for badge routes

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,57 +1,14 @@
 home:
     path: /
-    defaults: { _controller: 'App\Controller\HomeController::index' }
+    controller: App\Controller\HomeController::indexAction
 
 snippet_all:
     path: /snippet/all/
     defaults: { _controller: 'App\Controller\SnippetController::all' }
 
-pugx_badge_version_latest:
-    path: /{repository}/v/{latest}
-    controller: App\Controller\Badge\VersionController::versionAction
-    defaults:   { latest: "stable" }
-    requirements:
-        latest: "stable|unstable"
-        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
-
-pugx_badge_license:
-    path: /{repository}/license
-    controller: App\Controller\Badge\LicenseController::licenseAction
-    requirements:
-        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
-
-pugx_badge_download:
-    path: /{repository}/downloads
-    controller: App\Controller\Badge\DownloadsController::downloadsAction
-    defaults:   { type: "total" }
-    requirements:
-        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
-
-pugx_badge_download_type:
-    path: /{repository}/d/{type}
-    controller: App\Controller\Badge\DownloadsController::downloadsAction
-    requirements:
-        type: "total|daily|monthly"
-        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
-
-pugx_badge_version:
-    path:       /{repository}/version
-    controller: App\Controller\Badge\VersionController::versionAction
-    defaults:   { latest: "stable" }
-    requirements:
-        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
-
-pugx_badge_composerlock:
-    path: /{repository}/composerlock
-    controller: App\Controller\Badge\ComposerLockController:composerLockAction
-    requirements:
-        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
-
-pugx_badge_gitattributes:
-    path: /{repository}/gitattributes
-    controller: App\Controller\Badge\GitAttributesController::gitAttributesAction
-    requirements:
-        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
-
 pugx_badge_packagist:
-    path: /
+    path: /packages/{repository}
+    host: "packagist.org"
+    schemes:  [https]
+    requirements:
+      repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+"

--- a/config/routes/badge.yaml
+++ b/config/routes/badge.yaml
@@ -1,0 +1,67 @@
+pugx_badge_version:
+    path:       /{repository}/version.{_ext}
+    controller: App\Controller\Badge\VersionController::versionAction
+    defaults:
+        latest: "stable"
+        _ext: "svg"
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        _ext: "svg"
+
+pugx_badge_version_latest:
+    path: /{repository}/v/{latest}.{_ext}
+    controller: App\Controller\Badge\VersionController::versionAction
+    defaults:
+        latest: "stable"
+        _ext: "svg"
+    requirements:
+        latest: "stable|unstable"
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        _ext: "svg"
+
+pugx_badge_license:
+    path: /{repository}/license.{_ext}
+    controller: App\Controller\Badge\LicenseController::licenseAction
+    defaults:
+        _ext: "svg"
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        _ext: "svg"
+
+pugx_badge_download:
+    path: /{repository}/downloads.{_ext}
+    controller: App\Controller\Badge\DownloadsController::downloadsAction
+    defaults:
+        type: "total"
+        _ext: "svg"
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        _ext: "svg"
+
+pugx_badge_download_type:
+    path: /{repository}/d/{type}.{_ext}
+    controller: App\Controller\Badge\DownloadsController::downloadsAction
+    defaults:
+        _ext: "svg"
+    requirements:
+        type: "total|daily|monthly"
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        _ext: "svg"
+
+pugx_badge_composerlock:
+    path: /{repository}/composerlock.{_ext}
+    controller: App\Controller\Badge\ComposerLockController:composerLockAction
+    defaults:
+        _ext: "svg"
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        _ext: "svg"
+
+pugx_badge_gitattributes:
+    path: /{repository}/gitattributes.{_ext}
+    controller: App\Controller\Badge\GitAttributesController::gitAttributesAction
+    defaults:
+        _ext: "svg"
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        _ext: "svg"

--- a/config/routes/badge_redirect.yaml
+++ b/config/routes/badge_redirect.yaml
@@ -1,0 +1,53 @@
+download_png_redirect:
+    path: /{repository}/downloads.png
+    defaults:
+        _controller: FrameworkBundle:Redirect:redirect
+        route: pugx_badge_download
+        permanent: true
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+    methods:  [GET]
+
+download_type_png_redirect:
+    path: /{repository}/d/{type}.png
+    defaults:
+        _controller: FrameworkBundle:Redirect:redirect
+        route: pugx_badge_download_type
+        permanent: true
+        type: "total"
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        type: "total|daily|monthly"
+    methods:  [GET]
+
+badge_version_png_redirect:
+    path: /{repository}/version.png
+    defaults:
+        _controller: FrameworkBundle:Redirect:redirect
+        route: pugx_badge_version
+        permanent: true
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+    methods:  [GET]
+
+version_latest_png_redirect:
+    path: /{repository}/v/{latest}.png
+    defaults:
+        _controller: FrameworkBundle:Redirect:redirect
+        route: pugx_badge_version_latest
+        permanent: true
+        latest: "stable"
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        type: "stable|unstable"
+    methods:  [GET]
+
+badge_license_png_redirect:
+    path: /{repository}/license.png
+    defaults:
+        _controller: FrameworkBundle:Redirect:redirect
+        route: pugx_badge_license
+        permanent: true
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+    methods:  [GET]

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -4,18 +4,16 @@ namespace App\Controller;
 
 use App\Contributors\Service\Repository as ContributorsRepository;
 use App\Contributors\Model\Contributor;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 
 class HomeController extends Controller
 {
     /**
-     * @Route("/", name="homepage")
      * @param ContributorsRepository $contributorsRepository
      * @return Response
      */
-    public function index(ContributorsRepository $contributorsRepository): Response
+    public function indexAction(ContributorsRepository $contributorsRepository): Response
     {
         /** @var Contributor[] $contributors */
         $contributors = $contributorsRepository->all();

--- a/tests/Controller/Badge/ComposerLockControllerTest.php
+++ b/tests/Controller/Badge/ComposerLockControllerTest.php
@@ -21,4 +21,12 @@ class ComposerLockControllerTest extends WebTestCase
         $client->request('GET', '/pugx/badge-poser/composerlock');
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
+
+    public function testComposerLockSvgExplicit()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/pugx/badge-poser/composerlock.svg');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
 }

--- a/tests/Controller/Badge/DownloadsControllerTest.php
+++ b/tests/Controller/Badge/DownloadsControllerTest.php
@@ -42,4 +42,29 @@ class DownloadsControllerTest extends WebTestCase
         $client->request('GET', '/pugx/badge-poser/d/monthly');
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
+
+    public function testDownloadsActionSvgExplicit()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/pugx/badge-poser/downloads.svg');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    public function testDownloadsTotalActionSvgExplicit()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/pugx/badge-poser/d/total.svg');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    public function testDownloadsActionPngRedirectSvg()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/pugx/badge-poser/downloads.png');
+        $crawler = $client->followRedirect();
+
+        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->assertContains('/pugx/badge-poser/downloads', $crawler->getUri());
+    }
 }

--- a/tests/Controller/Badge/GitAttributesBadgeControllerTest.php
+++ b/tests/Controller/Badge/GitAttributesBadgeControllerTest.php
@@ -18,7 +18,7 @@ class GitAttributesBadgeControllerTest extends WebTestCase
     /**
      * @group gitattributes
      */
-    public function testGitattributesResponseUncommitted()
+    public function testGitAttributesResponseUncommitted()
     {
         $client = static::createClient();
         $client->request('GET', '/pugx/badge-poser/gitattributes');
@@ -35,7 +35,7 @@ class GitAttributesBadgeControllerTest extends WebTestCase
     /**
      * @group gitattributes
      */
-    public function testGitattributesResponseCommitted()
+    public function testGitAttributesResponseCommitted()
     {
         $client = static::createClient();
         $client->request('GET', '/stolt/lean-package-validator/gitattributes');
@@ -47,5 +47,12 @@ class GitAttributesBadgeControllerTest extends WebTestCase
 
         $this->assertRegExp('/.gitattributes/', $svgContent);
         $this->assertRegExp('/committed/', $svgContent);
+    }
+
+    public function testGitAttributesSvgExplicit()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/pugx/badge-poser/gitattributes.svg');
+        $this->assertTrue($client->getResponse()->isSuccessful());
     }
 }

--- a/tests/Controller/Badge/LicenseControllerTest.php
+++ b/tests/Controller/Badge/LicenseControllerTest.php
@@ -22,4 +22,22 @@ class LicenseControllerTest extends WebTestCase
         $client->request('GET', '/pugx/badge-poser/license');
         $this->assertTrue($client->getResponse()->isSuccessful(), $client->getResponse()->getContent());
     }
+
+    public function testLicenseActionSvgExplicit()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/pugx/badge-poser/license.svg');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    public function testLicenseActionPngRedirectSvg()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/pugx/badge-poser/license.png');
+        $crawler = $client->followRedirect();
+
+        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->assertContains('/pugx/badge-poser/license', $crawler->getUri());
+    }
 }

--- a/tests/Controller/Badge/VersionControllerTest.php
+++ b/tests/Controller/Badge/VersionControllerTest.php
@@ -43,4 +43,28 @@ class VersionControllerTest extends WebTestCase
         $this->assertRegExp('/s-maxage=3600/', $client->getResponse()->headers->get('Cache-Control'));
     }
 
+    public function testLatestStableActionSvgExplicit()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/pugx/badge-poser/version.svg');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    public function testLatestUnstableActionSvgExplicit()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/pugx/badge-poser/v/unstable.svg');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    public function testLatestStableActionPngRedirectSvg()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/pugx/badge-poser/version.png');
+        $crawler = $client->followRedirect();
+
+        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->assertContains('/pugx/badge-poser/version', $crawler->getUri());
+    }
 }


### PR DESCRIPTION
I added the redirect routes for the badge routes in png.
I created a specific file for badge and redirect route.
I edited the config badge route for work with .svg extension and without .svg extension.
I removed a duplicate configuration for the homepage route.
I added a tests!

https://trello.com/c/Ep4OZDoy/25-no-backwards-compatibility-per-gli-alias-e-rotte-vecchie