### PR TITLE
Run php-cs-fixer disabling xdebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,10 @@ docker-compose exec php-fpm ./bin/phpunit
 ``` bash
 docker-compose exec php-fpm ./vendor/bin/php-cs-fixer fix -v
 ```
+
+
+- Run php-cs-fixer disabling xdebug (it's much faster):
+
+``` bash
+docker-compose exec php-fpm bash php-no-xdebug ./vendor/bin/php-cs-fixer fix -v
+```

--- a/docker/dev/php-fpm/Dockerfile
+++ b/docker/dev/php-fpm/Dockerfile
@@ -75,5 +75,8 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
 COPY ./docker-entrypoint.sh /usr/local/bin/docker-app-entrypoint
 RUN chmod +x /usr/local/bin/docker-app-entrypoint
 
+COPY ./php-no-xdebug.sh /usr/local/bin/php-no-xdebug
+RUN chmod +x /usr/local/bin/php-no-xdebug
+
 ENTRYPOINT ["docker-app-entrypoint"]
 CMD ["php-fpm"]

--- a/docker/dev/php-fpm/php-no-xdebug.sh
+++ b/docker/dev/php-fpm/php-no-xdebug.sh
@@ -1,0 +1,66 @@
+# file /usr/local/bin/php-no-xdebug
+#!/bin/bash
+
+php=$(which php)
+
+# get the xdebug config
+xdebugConfig=$(php -i | grep xdebug | while read line; do echo $line; exit; done)
+# remove comma by last char
+xdebugConfig=${xdebugConfig::-1}
+
+# no xdebug? Nothing to do!
+if [ "$xdebugConfig" == "" ]; then
+    $php "$@"
+    exit
+fi
+
+# get the configfile (which should be the first value)
+# so strip off everything after the first space of the xdebug-config
+xdebugConfigFile=$(php -i | grep xdebug | while read line; do echo $line; exit; done)
+# remove comma by last char
+xdebugConfigFile=${xdebugConfigFile::-1}
+
+
+# test whether we got it right
+if [ ! -f "$xdebugConfigFile" ]; then
+    echo "No XDebug configfile found!"
+    exit 1
+fi
+
+# disable xdebug by renaming the relevant .ini file
+mv ${xdebugConfigFile}{,.bak}
+
+# dissect the argument to extract the first one (which should be a script or an application in $PATH) from the rest
+index=0
+for arg in $(echo $@ | tr ' ' "\n")
+do
+    if [ "$index" == "0" ]; then
+        firstArg=$arg
+    else
+      restArg="$restArg $arg"
+    fi
+
+   ((index++))
+done
+
+# check whether the command to be executed is a local PHP file or something in the $PATH like composer or php-cs-fixer
+fullPath="$(which $firstArg)"
+if [ "$fullPath" == "" ]; then
+    # just run the commands
+    $php $@
+else
+    # run the command with the fullpath followed by the rest of the arguments provided
+    $php $fullPath $restArg
+fi
+
+# execute the command
+#$php "$@"
+
+# re-enable xdebug
+mv ${xdebugConfigFile}{.bak,}
+
+# test whether the conf file is restored correctly
+if [ ! -f "$xdebugConfigFile" ]; then
+    echo "Something went wrong with restoring the configfile for xdebug!"
+    exit 1
+fi


### PR DESCRIPTION
Running php-cs-fixer with xdebug disabled greatly improves running time. 
To do this, rebuild docker-compose `docker-compose up --build -d`!