### PR TITLE
Update composer install to use programmatic install 

### DIFF
--- a/docker/dev/php-fpm/Dockerfile
+++ b/docker/dev/php-fpm/Dockerfile
@@ -67,10 +67,8 @@ RUN echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install composer
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-    && php composer-setup.php --filename=composer --install-dir=/usr/local/bin/ \
-    && rm composer-setup.php
+COPY ./composer-install.sh /tmp/composer-install.sh
+RUN chmod +x /tmp/composer-install.sh && /tmp/composer-install.sh && rm /tmp/composer-install.sh
 
 COPY ./docker-entrypoint.sh /usr/local/bin/docker-app-entrypoint
 RUN chmod +x /usr/local/bin/docker-app-entrypoint

--- a/docker/dev/php-fpm/composer-install.sh
+++ b/docker/dev/php-fpm/composer-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('SHA384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet --filename=composer --install-dir=/usr/local/bin
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
The current composer install in the Dockerfile has hard coded the hash. This changes every time composer updates.

Instead, I've updated to make it use the programmatic install which downloads the hash on the fly.
https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md