### PR TITLE
Lock node image to 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   node:
     container_name: badge-poser-node
-    image: node:alpine
+    image: node:8-alpine
     user: "node"
     volumes:
       - .:/application:cached


### PR DESCRIPTION
Latest node image (10.12.0) is incompatible with upath@1.0.2 dep - lock to node 8 image until it's updated

Looks like upath@1.0.5 fixes it so probably not a hard one.

Error message:
error upath@1.0.2: The engine "node" is incompatible with this module. Expected version ">=4 <=9". Got "10.12.0"