### PR TITLE
V3/replace guzzle with httpclient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": "^7.2",
         "ext-gd": "*",
         "ext-iconv": "*",
+        "ext-json": "*",
         "badges/poser": "^1.3",
         "cache/predis-adapter": "^1.0",
         "knplabs/github-api": "^2.8",
@@ -31,6 +32,7 @@
         "symfony/console": "*",
         "symfony/flex": "*",
         "symfony/framework-bundle": "*",
+        "symfony/http-client": "*",
         "symfony/webpack-encore-bundle": "*",
         "symfony/yaml": "*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f455a3586b99199a68c7b99446be1e4",
+    "content-hash": "ad370fdb46789be1c5a0315a5d918a44",
     "packages": [
         {
             "name": "badges/poser",
@@ -2769,6 +2769,125 @@
             "description": "Symfony FrameworkBundle",
             "homepage": "https://symfony.com",
             "time": "2019-05-30T03:17:01+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "fec81f1da93f50334085b00113d2fb6f34efc801"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/fec81f1da93f50334085b00113d2fb6f34efc801",
+                "reference": "fec81f1da93f50334085b00113d2fb6f34efc801",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "^1.0",
+                "symfony/http-client-contracts": "^1.1",
+                "symfony/polyfill-php73": "^1.11"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "1.1"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.0",
+                "psr/http-client": "^1.0",
+                "symfony/http-kernel": "^4.3",
+                "symfony/process": "^4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpClient component",
+            "homepage": "https://symfony.com",
+            "time": "2019-05-28T08:25:44+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "c87486c0fa65ae04736140389037fcbdd149ddd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/c87486c0fa65ae04736140389037fcbdd149ddd6",
+                "reference": "c87486c0fa65ae04736140389037fcbdd149ddd6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "symfony/http-client-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-05-22T12:23:29+00:00"
         },
         {
             "name": "symfony/http-foundation",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -52,7 +52,7 @@ services:
     App\Service\CircleCiClient:
         arguments:
             - '@router'
-            - '@GuzzleHttp\Client'
+            - '@Symfony\Contracts\HttpClient\HttpClientInterface'
             - '%app.circle_ci_token%'
     App\Service\CircleCiClientInterface: '@App\Service\CircleCiClient'
 

--- a/src/Badge/Model/UseCase/CreateCircleCiBadge.php
+++ b/src/Badge/Model/UseCase/CreateCircleCiBadge.php
@@ -16,6 +16,8 @@ use App\Badge\Model\Package;
 use App\Badge\Model\PackageRepositoryInterface;
 use App\Service\CircleCiClientInterface;
 use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 use UnexpectedValueException;
 
 /**
@@ -66,12 +68,12 @@ class CreateCircleCiBadge extends BaseCreatePackagistImage
 
             $response = $this->circleCiClient->getBuilds($repository, $branch);
 
-            if (200 !== $response->getStatusCode()) {
+            if (Response::HTTP_OK !== $response->getStatusCode()) {
                 return $this->createDefaultBadge($format);
             }
 
-            $builds = json_decode($response->getBody()->getContents(), true);
-        } catch (\Exception $e) {
+            $builds = json_decode($response->getContent(), true);
+        } catch (Throwable $e) {
             return $this->createDefaultBadge($format);
         }
 

--- a/src/Service/CircleCiClient.php
+++ b/src/Service/CircleCiClient.php
@@ -2,34 +2,32 @@
 
 namespace App\Service;
 
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\GuzzleException;
-use Psr\Http\Message\ResponseInterface;
-use Symfony\Component\Routing\Exception\InvalidParameterException;
-use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class CircleCiClient implements CircleCiClientInterface
 {
     /** @var UrlGeneratorInterface */
     protected $router;
 
-    /** @var ClientInterface */
-    protected $client;
+    /** @var HttpClientInterface */
+    protected $httpClient;
 
     /** @var string */
     protected $circleToken;
 
     /**
      * @param UrlGeneratorInterface $router
-     * @param ClientInterface       $client
+     * @param HttpClientInterface   $httpClient
      * @param string                $circleToken
      */
-    public function __construct(UrlGeneratorInterface $router, ClientInterface $client, string $circleToken)
+    public function __construct(UrlGeneratorInterface $router, HttpClientInterface $httpClient, string $circleToken)
     {
         $this->router = $router;
-        $this->client = $client;
+        $this->httpClient = $httpClient;
         $this->circleToken = $circleToken;
     }
 
@@ -39,17 +37,14 @@ class CircleCiClient implements CircleCiClientInterface
      *
      * @return ResponseInterface
      *
-     * @throws RouteNotFoundException
-     * @throws MissingMandatoryParametersException
-     * @throws InvalidParameterException
-     * @throws GuzzleException
+     * @throws TransportExceptionInterface
      */
     public function getBuilds(string $repository, string $branch = 'master'): ResponseInterface
     {
         $circleCiApiUrl = $this->router->generate('circleci_api', ['repository' => $repository, 'branch' => urlencode($branch)]);
 
-        return $this->client->request(
-            'GET',
+        return $this->httpClient->request(
+            Request::METHOD_GET,
             $circleCiApiUrl,
             [
                 'headers' => [

--- a/src/Service/CircleCiClientInterface.php
+++ b/src/Service/CircleCiClientInterface.php
@@ -2,7 +2,7 @@
 
 namespace App\Service;
 
-use Psr\Http\Message\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 interface CircleCiClientInterface
 {

--- a/symfony.lock
+++ b/symfony.lock
@@ -272,6 +272,12 @@
             "ref": "99d0a737bb3a14a25530fc8c528aa2a632f43079"
         }
     },
+    "symfony/http-client": {
+        "version": "v4.3.0"
+    },
+    "symfony/http-client-contracts": {
+        "version": "v1.1.1"
+    },
     "symfony/http-foundation": {
         "version": "v4.2.1"
     },

--- a/tests/Badge/Model/UseCase/CreateCircleCiBadgeTest.php
+++ b/tests/Badge/Model/UseCase/CreateCircleCiBadgeTest.php
@@ -17,9 +17,8 @@ use App\Badge\Model\UseCase\CreateCircleCiBadge;
 use App\Service\CircleCiClientInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamInterface;
 use RuntimeException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * Class CreateCircleCiBadgeTest.
@@ -69,25 +68,16 @@ final class CreateCircleCiBadgeTest extends TestCase
             ['getRepository']
         );
 
-        $response = $this->createMockWithoutInvokingTheOriginalConstructor(
-            ResponseInterface::class,
-            ['getStatusCode', 'withStatus', 'getReasonPhrase', 'getProtocolVersion', 'withProtocolVersion', 'getHeaders', 'hasHeader', 'getHeader', 'getHeaderLine', 'withHeader', 'withAddedHeader', 'withoutHeader', 'getBody', 'withBody']
-        );
+        $response = $this->getMockBuilder(ResponseInterface::class)
+            ->disableOriginalConstructor()->getMock();
 
         $response->expects($this->once())
             ->method('getStatusCode')
             ->willReturn(200);
 
-        $responseBody = $this->getMockBuilder(StreamInterface::class)
-            ->getMockForAbstractClass();
-
-        $responseBody->expects($this->once())
-            ->method('getContents')
-            ->willReturn(json_encode([['status' => $status]]));
-
         $response->expects($this->once())
-            ->method('getBody')
-            ->willReturn($responseBody);
+            ->method('getContent')
+            ->willReturn(json_encode([['status' => $status]]));
 
         $this->circleCiClient->expects($this->once())
             ->method('getBuilds')
@@ -150,25 +140,16 @@ final class CreateCircleCiBadgeTest extends TestCase
             ['getRepository']
         );
 
-        $response = $this->createMockWithoutInvokingTheOriginalConstructor(
-            ResponseInterface::class,
-            ['getStatusCode', 'withStatus', 'getReasonPhrase', 'getProtocolVersion', 'withProtocolVersion', 'getHeaders', 'hasHeader', 'getHeader', 'getHeaderLine', 'withHeader', 'withAddedHeader', 'withoutHeader', 'getBody', 'withBody']
-        );
+        $response = $this->getMockBuilder(ResponseInterface::class)
+            ->disableOriginalConstructor()->getMock();
 
         $response->expects($this->once())
             ->method('getStatusCode')
             ->willReturn(200);
 
-        $responseBody = $this->getMockBuilder(StreamInterface::class)
-            ->getMockForAbstractClass();
-
-        $responseBody->expects($this->once())
-            ->method('getContents')
-            ->willReturn(json_encode([]));
-
         $response->expects($this->once())
-            ->method('getBody')
-            ->willReturn($responseBody);
+            ->method('getContent')
+            ->willReturn(json_encode([]));
 
         $this->circleCiClient->expects($this->once())
             ->method('getBuilds')
@@ -195,10 +176,12 @@ final class CreateCircleCiBadgeTest extends TestCase
             ['getRepository']
         );
 
-        $response = $this->createMockWithoutInvokingTheOriginalConstructor(
-            ResponseInterface::class,
-            ['getStatusCode', 'withStatus', 'getReasonPhrase', 'getProtocolVersion', 'withProtocolVersion', 'getHeaders', 'hasHeader', 'getHeader', 'getHeaderLine', 'withHeader', 'withAddedHeader', 'withoutHeader', 'getBody', 'withBody']
-        );
+//        $response = $this->createMockWithoutInvokingTheOriginalConstructor(
+//            ResponseInterface::class,
+//            ['getStatusCode', 'withStatus', 'getReasonPhrase', 'getProtocolVersion', 'withProtocolVersion', 'getHeaders', 'hasHeader', 'getHeader', 'getHeaderLine', 'withHeader', 'withAddedHeader', 'withoutHeader', 'getBody', 'withBody']
+//        );
+        $response = $this->getMockBuilder(ResponseInterface::class)
+            ->disableOriginalConstructor()->getMock();
 
         $response->expects($this->once())
             ->method('getStatusCode')


### PR DESCRIPTION
I add symfony httpClient dependency and replace the use of guzzle with httpClient in badge generator circle ci.