### PR TITLE
add git hook to run phpunit, php-cs-fixer and phpstan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 npm-debug.log
 yarn-error.log
 ###< symfony/webpack-encore-bundle ###
+cghooks.lock
+

--- a/README.md
+++ b/README.md
@@ -86,3 +86,5 @@ docker-compose exec php-fpm ./vendor/bin/php-cs-fixer fix -v
 ``` bash
 $ docker-compose exec php-fpm ./vendor/bin/phpstan analyse
 ```
+
+A pre-commit git hook to run `phpunit`, `php-cs-fixer` and `phpstan` is automatically installed

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "symfony/yaml": "*"
     },
     "require-dev": {
+        "brainmaestro/composer-git-hooks": "^2.8",
         "friendsofphp/php-cs-fixer": "^2.13",
         "phpstan/phpstan": "^0.11.8",
         "phpstan/phpstan-phpunit": "^0.11.2",
@@ -76,16 +77,25 @@
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
         "post-install-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "cghooks add --ignore-lock"
         ],
         "post-update-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "cghooks update"
         ]
     },
     "conflict": {
         "symfony/symfony": "*"
     },
     "extra": {
+        "hooks": {
+            "pre-commit": [
+                "./bin/phpunit",
+                "./vendor/bin/php-cs-fixer fix -v",
+                "./vendor/bin/phpstan analyse"
+            ]
+        },
         "symfony": {
             "id": "01C6YZAVV83WQGHCHEWX2SA6KC",
             "allow-contrib": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17c22549f2e3cc3b8def9abedc6ea568",
+    "content-hash": "85527c521dd65396de9ad03ffc8aa962",
     "packages": [
         {
             "name": "badges/poser",
@@ -4180,6 +4180,75 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "brainmaestro/composer-git-hooks",
+            "version": "v2.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/BrainMaestro/composer-git-hooks.git",
+                "reference": "c4a39fcbd73b8a5da8c02b8e0923b0836cc4fae0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BrainMaestro/composer-git-hooks/zipball/c4a39fcbd73b8a5da8c02b8e0923b0836cc4fae0",
+                "reference": "c4a39fcbd73b8a5da8c02b8e0923b0836cc4fae0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || >=7.0",
+                "symfony/console": "^3.2 || ^4.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "friendsofphp/php-cs-fixer": "^2.9",
+                "phpunit/phpunit": "^5.7 || ^7.0"
+            },
+            "bin": [
+                "cghooks"
+            ],
+            "type": "library",
+            "extra": {
+                "hooks": {
+                    "pre-commit": "composer check-style",
+                    "pre-push": [
+                        "composer test",
+                        "appver=$(grep -o -E '\\d.\\d.\\d' cghooks)",
+                        "tag=$(git describe --tags --abbrev=0)",
+                        "if [ \"$tag\" != \"v$appver\" ]; then",
+                        "echo \"The most recent tag $tag does not match the application version $appver\\n\"",
+                        "tag=${tag#v}",
+                        "sed -i -E \"s/$appver/$tag/\" cghooks",
+                        "exit 1",
+                        "fi"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "BrainMaestro\\GitHooks\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ezinwa Okpoechi",
+                    "email": "brainmaestro@outlook.com"
+                }
+            ],
+            "description": "Easily manage git hooks in your composer config",
+            "keywords": [
+                "HOOK",
+                "composer",
+                "git"
+            ],
+            "time": "2019-10-16T14:14:51+00:00"
+        },
         {
             "name": "composer/semver",
             "version": "1.5.0",

--- a/symfony.lock
+++ b/symfony.lock
@@ -2,6 +2,9 @@
     "badges/poser": {
         "version": "v1.3.0"
     },
+    "brainmaestro/composer-git-hooks": {
+        "version": "v2.8.2"
+    },
     "cache/adapter-common": {
         "version": "1.1.0"
     },


### PR DESCRIPTION
This PR adds the brainmaestro/composer-git-hooks package and installs a pre-commit git hook to run phpunit, php-cs-fixer and phpstan. closes #270 