### PR TITLE
re-enable proper nginx conf for dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - phpfpm
     volumes:
       - .:/application:cached
+      - ./docker/dev/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
       - 8001:80
 

--- a/docker/dev/nginx/nginx.conf
+++ b/docker/dev/nginx/nginx.conf
@@ -11,7 +11,7 @@ server {
         #set $upstream_host app;
         #fastcgi_pass $upstream_host:9000;
         # Uncomment the previous lines and comment the next one to enable dynamic resolution (incompatible with Kubernetes)
-        fastcgi_pass php-fpm:9000;
+        fastcgi_pass phpfpm:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         # When you are using symlinks to link the document root to the


### PR DESCRIPTION
This partially reverts some changes done in c21ed42dca2bf9d1f706ede5c2de69b4b1feada2, that prevented local dev env from properly run nginx and fpm