### PR TITLE
feat: add badge php version require

### DIFF
--- a/config/routes/badge.yaml
+++ b/config/routes/badge.yaml
@@ -102,3 +102,14 @@ pugx_badge_circleci:
         repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
         branch: ".+"
         _ext: "svg"
+
+pugx_badge_require:
+    path: /{repository}/require/{type}.{_ext}
+    controller: App\Controller\Badge\RequireController::require
+    methods: GET
+    defaults:
+        _ext: "svg"
+    requirements:
+        repository: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?"
+        type: ".+"
+        _ext: "svg"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,6 +9,7 @@ parameters:
         - 'total'
         - 'latest_unstable_version'
         - 'license'
+        - 'require_php'
 
     pugx_badge_badges:
         - { name: 'latest_stable_version', label: 'Latest Stable Version', route: "pugx_badge_version_latest", latest: 'stable'}
@@ -18,6 +19,7 @@ parameters:
         - { name: 'monthly', label: 'Monthly Downloads', route: "pugx_badge_download_type", type: 'monthly'}
         - { name: 'daily', label: 'Daily Downloads', route: "pugx_badge_download_type", type: 'daily'}
         - { name: 'version', label: 'Version', route: "pugx_badge_version" }
+        - { name: 'require_php', label: 'PHP Version Require', route: "pugx_badge_require", type: 'php'}
         - { name: 'composerlock', label: 'composer.lock', route: "pugx_badge_composerlock" }
         - { name: 'gitattributes', label: '.gitattributes', route: "pugx_badge_gitattributes" }
         - { name: 'dependents', label: 'Dependents', route: "pugx_badge_dependents"}

--- a/src/Badge/Model/Package.php
+++ b/src/Badge/Model/Package.php
@@ -290,4 +290,14 @@ final class Package
 
         return '';
     }
+
+    public function getLatestRequire(string $require): string
+    {
+        $latestStableVersion = $this->getLatestStableVersion();
+        /** @var Version $version */
+        $version = $this->getVersions()[$latestStableVersion];
+        $requires = $version->getRequire();
+
+        return $requires[$require] ?? '';
+    }
 }

--- a/src/Badge/Model/UseCase/CreateRequireBadge.php
+++ b/src/Badge/Model/UseCase/CreateRequireBadge.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the badge-poser package.
+ *
+ * (c) PUGX <http://pugx.github.io/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Badge\Model\UseCase;
+
+use App\Badge\Model\CacheableBadge;
+use App\Badge\Model\Package;
+use App\Badge\Model\PackageRepositoryInterface;
+
+/**
+ * Create the 'require' image with the standard Font and standard Image.
+ */
+final class CreateRequireBadge extends BaseCreatePackagistImage
+{
+    public const COLOR = '787CB5';
+    public const TEXT_NO_REQUIRE = ' - ';
+
+    private const TTL_DEFAULT_MAXAGE = CacheableBadge::TTL_ONE_HOUR;
+    private const TTL_DEFAULT_SMAXAGE = CacheableBadge::TTL_ONE_HOUR;
+
+    public function __construct(
+        PackageRepositoryInterface $packageRepository
+    ) {
+        parent::__construct($packageRepository);
+    }
+
+    public function createRequireBadge(string $repository, string $type, string $format = 'svg'): CacheableBadge
+    {
+        return $this->createBadgeFromRepository(
+            $repository,
+            $type,
+            self::COLOR,
+            $format,
+            $type,
+            self::TTL_DEFAULT_MAXAGE,
+            self::TTL_DEFAULT_SMAXAGE
+        );
+    }
+
+    protected function prepareText(Package $package, ?string $context): string
+    {
+        $require = $package->getLatestRequire((string) $context);
+
+        return empty($require) ? self::TEXT_NO_REQUIRE : $require;
+    }
+}

--- a/src/Controller/Badge/RequireController.php
+++ b/src/Controller/Badge/RequireController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Controller\Badge;
+
+use App\Badge\Model\UseCase\CreateRequireBadge;
+use App\Badge\Service\ImageFactory;
+use PUGX\Poser\Poser;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RequireController extends AbstractBadgeController
+{
+    public function require(
+        Request $request,
+        Poser $poser,
+        CreateRequireBadge $createRequireBadge,
+        ImageFactory $imageFactory,
+        string $repository,
+        string $type,
+        string $format = 'svg'
+    ): Response {
+        if (\in_array($request->query->get('format'), $poser->validStyles(), true)) {
+            $format = (string) $request->query->get('format');
+        }
+
+        return $this->serveBadge(
+            $imageFactory,
+            $createRequireBadge->createRequireBadge($repository, $type, $format)
+        );
+    }
+}

--- a/tests/Badge/Model/UseCase/CreateRequireBadgeTest.php
+++ b/tests/Badge/Model/UseCase/CreateRequireBadgeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Tests\Badge\Model\UseCase;
+
+use App\Badge\Model\Package;
+use App\Badge\Model\PackageRepositoryInterface;
+use App\Badge\Model\UseCase\CreateRequireBadge;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class CreateRequireBadgeTest extends TestCase
+{
+    private CreateRequireBadge $useCase;
+    /** @var PackageRepositoryInterface|MockObject */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(PackageRepositoryInterface::class);
+        $this->useCase = new CreateRequireBadge($this->repository);
+    }
+
+    public function testShouldCreateRequireBadge(): void
+    {
+        $package = $this->getMockBuilder(Package::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getLatestRequire'])
+            ->getMock();
+
+        $package->expects(self::once())
+            ->method('getLatestRequire')
+            ->willReturn('^8.0');
+
+        $this->repository
+            ->method('fetchByRepository')
+            ->willReturn($package);
+
+        $repository = 'PUGX/badge-poser';
+        $type = 'php';
+        $badge = $this->useCase->createRequireBadge($repository, $type);
+        self::assertEquals($type, $badge->getSubject());
+        self::assertEquals('^8.0', $badge->getStatus());
+        self::assertEquals('#787CB5', $badge->getHexColor());
+    }
+
+    public function testShouldCreateDefaultBadgeOnError(): void
+    {
+        $this->repository
+            ->method('fetchByRepository')
+            ->will(self::throwException(new \RuntimeException()));
+
+        $repository = 'PUGX/badge-poser';
+        $type = 'php';
+        $badge = $this->useCase->createRequireBadge($repository, $type);
+
+        self::assertEquals(' - ', $badge->getSubject());
+        self::assertEquals(' - ', $badge->getStatus());
+        self::assertEquals('#7A7A7A', $badge->getHexColor());
+    }
+}

--- a/tests/Controller/Badge/RequireControllerTest.php
+++ b/tests/Controller/Badge/RequireControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Tests\Controller\Badge;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class RequireControllerTest extends WebTestCase
+{
+    public function testRequireAction(): void
+    {
+        $client = self::createClient();
+
+        $client->request('GET', '/pugx/badge-poser/require/php');
+        self::assertTrue($client->getResponse()->isSuccessful(), (string) $client->getResponse()->getContent());
+
+        self::assertMatchesRegularExpression('/max-age=3600/', (string) $client->getResponse()->headers->get('Cache-Control'));
+        self::assertMatchesRegularExpression('/s-maxage=3600/', (string) $client->getResponse()->headers->get('Cache-Control'));
+    }
+
+    public function testRequireActionSvgExplicit(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/pugx/badge-poser/require/php.svg');
+        self::assertResponseIsSuccessful();
+
+        self::assertMatchesRegularExpression('/max-age=3600/', (string) $client->getResponse()->headers->get('Cache-Control'));
+        self::assertMatchesRegularExpression('/s-maxage=3600/', (string) $client->getResponse()->headers->get('Cache-Control'));
+    }
+
+    public function testRequirePackageAction(): void
+    {
+        $client = self::createClient();
+
+        $client->request('GET', '/pugx/badge-poser/require/badges/poser');
+        self::assertTrue($client->getResponse()->isSuccessful(), (string) $client->getResponse()->getContent());
+
+        self::assertMatchesRegularExpression('/max-age=3600/', (string) $client->getResponse()->headers->get('Cache-Control'));
+        self::assertMatchesRegularExpression('/s-maxage=3600/', (string) $client->getResponse()->headers->get('Cache-Control'));
+    }
+}


### PR DESCRIPTION
closes #607

WDYT?

![Schermata 2021-08-24 alle 17 25 43](https://user-images.githubusercontent.com/190820/130644824-10d2ef0f-e3cf-4b88-9e27-09fb53539d7e.png)

The new badge works with all requires, example:
```
/phpunit/phpunit/require/php
/phpunit/phpunit/require/ext-gd
/phpunit/phpunit/require/badges/poser
```
