### PR TITLE
fix: stop check canary

### DIFF
--- a/sys/cloudformation/stack.yaml
+++ b/sys/cloudformation/stack.yaml
@@ -65,10 +65,6 @@ Parameters:
     Type: String
     Description: >
       Specifies the ECR Image Tag for PHP-FPM container.
-  EcrImageTagPhpCanary:
-    Type: String
-    Description: >
-      Specifies the ECR Image Tag for PHP-FPM dark-canary container.
   ELBCertificateArn:
     Type: String
     Description: >

--- a/sys/nginx/default.conf.template
+++ b/sys/nginx/default.conf.template
@@ -27,8 +27,6 @@ server {
 
     root /application/public;
 
-    if ($request_uri ~ "/dark-canary/") { set $skip_cache 1; }
-
     fastcgi_cache cached_badges;
     fastcgi_cache_methods GET HEAD;
     fastcgi_cache_key "$request_method@@$host@@$request_uri";
@@ -64,28 +62,6 @@ server {
     add_header X-Content-Type-Options nosniff;
     add_header X-Frame-Options SAMEORIGIN;
     add_header X-XSS-Protection "1; mode=block";
-
-    location ~ ^/dark-canary {
-        internal;
-
-        set_by_lua_block $request_url {
-            return string.gsub(ngx.var.request_uri, "/dark%-canary", "")
-        }
-        set_by_lua_block $document_url {
-            return string.gsub(ngx.var.document_uri, "/dark%-canary", "")
-        }
-
-        fastcgi_pass ${PHPFPM_CANARY_HOST}:9000;
-        fastcgi_split_path_info ^(.+\.php)(/.*)$;
-        fastcgi_buffers 16 16k;
-        fastcgi_buffer_size 32k;
-        include fastcgi_params;
-        fastcgi_param REQUEST_URI $request_url;
-        fastcgi_param DOCUMENT_URI $document_url;
-        fastcgi_param SCRIPT_NAME /index.php;
-        fastcgi_param SCRIPT_FILENAME /application/public/index.php;
-        fastcgi_param DOCUMENT_ROOT $realpath_root;
-    }
 
     location / {
         try_files $uri /index.php$is_args$args;

--- a/sys/nginx/lua/hook.lua
+++ b/sys/nginx/lua/hook.lua
@@ -20,8 +20,3 @@ if m1 or not m2 then return end
 
 local res = ngx.location.capture("/stats")
 
--- math.randomseed(os.time())
--- local odds = math.random(1, 100)
--- if odds <= dark_canary_threshold then
---     local res_darkcanary = ngx.location.capture("/dark-canary" .. ngx.var.request_uri)
--- end

--- a/sys/nginx/lua/hook.lua
+++ b/sys/nginx/lua/hook.lua
@@ -21,8 +21,8 @@ if m1 or not m2 then return end
 local res = ngx.location.capture("/stats")
 
 -- DARK CANARY
-math.randomseed(os.time())
-local odds = math.random(1, 100)
-if odds <= dark_canary_threshold then
-    local res_darkcanary = ngx.location.capture("/dark-canary" .. ngx.var.request_uri)
-end
+-- math.randomseed(os.time())
+-- local odds = math.random(1, 100)
+-- if odds <= dark_canary_threshold then
+--     local res_darkcanary = ngx.location.capture("/dark-canary" .. ngx.var.request_uri)
+-- end

--- a/sys/nginx/lua/hook.lua
+++ b/sys/nginx/lua/hook.lua
@@ -20,7 +20,6 @@ if m1 or not m2 then return end
 
 local res = ngx.location.capture("/stats")
 
--- DARK CANARY
 -- math.randomseed(os.time())
 -- local odds = math.random(1, 100)
 -- if odds <= dark_canary_threshold then

--- a/sys/nginx/lua/hook.lua
+++ b/sys/nginx/lua/hook.lua
@@ -1,6 +1,3 @@
--- skip dark-canary if found
-local m1 = ngx.re.match(ngx.var.request_uri, "^/dark-canary/")
-
 -- increase counter if valid path
 local regex = [[/(]]
 regex = regex .. [[circleci(/.+)?(\.svg)?]]
@@ -16,7 +13,7 @@ regex = regex .. [[|version(\.svg|\.png)?]]
 regex = regex .. [[)$]]
 
 local m2 = ngx.re.match(ngx.var.request_uri, regex)
-if m1 or not m2 then return end
+if not m2 then return end
 
 local res = ngx.location.capture("/stats")
 


### PR DESCRIPTION
I don't know why but from today I receive the following errors in dev environment that did 500.
I comment the lines in diff and now work!

@fabiocicerchia PTAL
 
```
badge-poser-nginx   | 172.18.0.1 - - [03/Jan/2022:09:43:47 +0000] "GET /phpunit/phpunit/composerlock HTTP/1.1" 500 572 "http://poser.local:8001/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36" "-" CACHE[GET@@poser.local@@/phpunit/phpunit/composerlock]:1:-
badge-poser-nginx   | 172.18.0.1 - - [03/Jan/2022:09:43:47 +0000] "GET /phpunit/phpunit/d/daily HTTP/1.1" 500 572 "http://poser.local:8001/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36" "-" CACHE[GET@@poser.local@@/phpunit/phpunit/d/daily]:1:-
badge-poser-nginx   | 172.18.0.1 - - [03/Jan/2022:09:43:47 +0000] "GET /phpunit/phpunit/version HTTP/1.1" 500 572 "http://poser.local:8001/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36" "-" CACHE[GET@@poser.local@@/phpunit/phpunit/version]:1:-
badge-poser-nginx   | 2022/01/03 09:43:47 [error] 29#29: *74 lua entry thread aborted: runtime error: /etc/nginx/conf.d/lua/hook.lua:26: attempt to compare number with nil
badge-poser-nginx   | stack traceback:
badge-poser-nginx   | coroutine 0:
badge-poser-nginx   | 	/etc/nginx/conf.d/lua/hook.lua: in main chunk, client: 172.18.0.1, server: poser.pugx.org, request: "GET /phpunit/phpunit/d/daily HTTP/1.1", host: "poser.local:8001", referrer: "http://poser.local:8001/"
badge-poser-nginx   | 2022/01/03 09:43:47 [error] 29#29: *73 lua entry thread aborted: runtime error: /etc/nginx/conf.d/lua/hook.lua:26: attempt to compare number with nil
badge-poser-nginx   | stack traceback:
badge-poser-nginx   | coroutine 0:
badge-poser-nginx   | 	/etc/nginx/conf.d/lua/hook.lua: in main chunk, client: 172.18.0.1, server: poser.pugx.org, request: "GET /phpunit/phpunit/version HTTP/1.1", host: "poser.local:8001", referrer: "http://poser.local:8001/"
badge-poser-nginx   | 172.18.0.1 - - [03/Jan/2022:09:43:47 +0000] "GET /phpunit/phpunit/dependents HTTP/1.1" 500 572 "http://poser.local:8001/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36" "-" CACHE[GET@@poser.local@@/phpunit/phpunit/dependents]:1:-
badge-poser-nginx   | 2022/01/03 09:43:47 [error] 29#29: *80 lua entry thread aborted: runtime error: /etc/nginx/conf.d/lua/hook.lua:26: attempt to compare number with nil
badge-poser-nginx   | stack traceback:
badge-poser-nginx   | coroutine 0:
badge-poser-nginx   | 	/etc/nginx/conf.d/lua/hook.lua: in main chunk, client: 172.18.0.1, server: poser.pugx.org, request: "GET /phpunit/phpunit/dependents HTTP/1.1", host: "poser.local:8001", referrer: "http://poser.local:8001/"
```

We can remove the dark canary logic right?