### PR TITLE
Fixed PHP Logo in the ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ or its latest stable version.
 [![Github actions Build](https://github.com/PUGX/badge-poser/workflows/Test/badge.svg)](https://packagist.org/packages/PUGX/badge-poser)
 [![Latest Stable Version](https://poser.pugx.org/pugx/badge-poser/version.svg)](https://packagist.org/packages/pugx/badge-poser)
 [![Latest Unstable Version](https://poser.pugx.org/pugx/badge-poser/v/unstable.svg)](https://packagist.org/packages/pugx/badge-poser)
-[![PHP Version Require](http://poser.pugx.org/pugx/badge-poser/require/php)](https://packagist.org/packages/pugx/badge-poser)
+[![PHP Version Require](https://poser.pugx.org/pugx/badge-poser/require/php)](https://packagist.org/packages/pugx/badge-poser)
 [![License](https://poser.pugx.org/pugx/badge-poser/license.svg)](https://packagist.org/packages/pugx/badge-poser)
 [![Downloads](https://poser.pugx.org/pugx/badge-poser/d/total.svg)](https://packagist.org/packages/pugx/badge-poser)
 [![composer.lock available](https://poser.pugx.org/pugx/badge-poser/composerlock)](https://packagist.org/packages/pugx/badge-poser)


### PR DESCRIPTION
It was annoying to see the PHP Logo as missing 😉 

Regards.