### PR TITLE
fix: github ribbons forkme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Follow [this link](https://circleci.com/account/api) to generate your CircleCI "
 
 Make the same for the `.env.test.local` to run the test suite.
 
-## Manage App with docker-compose
+## Manage App with Docker Compose
 
 ### Show the help
 

--- a/Makefile
+++ b/Makefile
@@ -22,40 +22,40 @@ run: ## run app
 	- make build_dev
 
 start: .docker_img_deps ## start docker containers
-	- docker-compose up --build -d
+	- docker compose up --build -d
 
 stop: ## stop docker containers
-	- docker-compose down
+	- docker compose down
 
 dc_build_prod: .docker_img_deps ## rebuild docker compose containers
-	- docker-compose up --build
+	- docker compose up --build
 
 purge: ## cleaning
 	- rm -rf node_modules vendor var/cache var/log public/build
 
 status: ## docker containers status
-	- docker-compose ps
+	- docker compose ps
 
 ##@ DEV
 
 install: ## install php and node dependencies
-	- docker-compose exec phpfpm composer install
-	- docker-compose run --rm node yarn install
+	- docker compose exec phpfpm composer install
+	- docker compose run --rm node yarn install
 
 build_dev: ## build assets
-	- docker-compose run --rm node yarn dev
+	- docker compose run --rm node yarn dev
 
 build_watch: ## build assets and watch
-	- docker-compose run --rm node yarn watch
+	- docker compose run --rm node yarn watch
 
 phpunit: ## run suite of tests
-	- docker-compose exec phpfpm bin/phpunit -d memory_limit=-1
+	- docker compose exec phpfpm bin/phpunit -d memory_limit=-1
 
 php_cs_fixer: ## run php-cs-fixer
-	- docker-compose exec phpfpm ./vendor/bin/php-cs-fixer fix -v
+	- docker compose exec phpfpm ./vendor/bin/php-cs-fixer fix -v
 
 phpstan: ## run phpstan
-	- docker-compose exec phpfpm ./vendor/bin/phpstan analyse
+	- docker compose exec phpfpm ./vendor/bin/phpstan analyse
 
 analyse: ## run php-cs-fixer and phpstan
 	- make php_cs_fixer
@@ -64,11 +64,11 @@ analyse: ## run php-cs-fixer and phpstan
 ##@ PROD
 
 install_prod: ## install php and node dependencies for production environment
-	- docker-compose exec phpfpm composer install --no-ansi --no-dev --no-interaction --no-plugins --no-progress --no-scripts --optimize-autoloader
-	- docker-compose run --rm node yarn install --production
+	- docker compose exec phpfpm composer install --no-ansi --no-dev --no-interaction --no-plugins --no-progress --no-scripts --optimize-autoloader
+	- docker compose run --rm node yarn install --production
 
 build_prod: ## build assets for production environment
-	- docker-compose run --rm node yarn build
+	- docker compose run --rm node yarn build
 
 ##@ DEPLOY
 

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -234,13 +234,6 @@ section.badges {
   }
 }
 
-.fork-me {
-  position: absolute;
-  top: 0;
-  right: 0;
-  border: 0;
-}
-
 @include media-breakpoint-down(sm) {
   .container.section-top {
     padding-right: 25px;
@@ -305,9 +298,32 @@ section.badges {
     display: inline-block;
     margin: 2px auto;
   }
+}
 
-  .fork-me {
-    max-width: 75px;
-    top: -5px;
+
+// https://sopkit.github.io/github-corners/
+.github-corner:hover .octo-arm {
+  animation: octocat-wave 560ms ease-in-out
+}
+
+@keyframes octocat-wave {
+  0%, 100% {
+    transform: rotate(0)
+  }
+  20%, 60% {
+    transform: rotate(-25deg)
+  }
+  40%, 80% {
+    transform: rotate(10deg)
+  }
+}
+
+@media (max-width: 500px) {
+  .github-corner:hover .octo-arm {
+    animation: none
+  }
+
+  .github-corner .octo-arm {
+    animation: octocat-wave 560ms ease-in-out
   }
 }

--- a/sys/README.md
+++ b/sys/README.md
@@ -41,7 +41,7 @@ Update the task definition and switch version in the service.
 ### Stable
 
 ```
-docker-compose up
+docker compose up
 npm install artillery
 ./node_modules/.bin/artillery run sys/docker/artillery.yml
 ```

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -2,11 +2,19 @@
 
 {% block body %}
 
-    <a href="https://github.com/PUGX/badge-poser">
-        <img class="fork-me"
-             src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67"
-             alt="Fork me on GitHub"
-             data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png">
+    <a href="https://github.com/PUGX/badge-poser"
+       class="github-corner" aria-label="View source on GitHub" target="_blank">
+        <svg width="80" height="80" viewBox="0 0 250 250"
+             style="fill:rgb(238, 29, 81); color:#fff; position: absolute; top: 0; border: 0; right: 0;"
+             aria-hidden="true">
+            <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+            <path
+                d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+                fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+            <path
+                d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+                fill="currentColor" class="octo-body"></path>
+        </svg>
     </a>
 
     <section class="container-fluid head d-flex align-items-center">


### PR DESCRIPTION
Before:
![Screenshot 2024-08-26 alle 15 27 47](https://github.com/user-attachments/assets/c7cceedd-03f8-4a00-9a3b-11bd6cd4c9e3)

After:
![Screenshot 2024-08-26 alle 15 28 16](https://github.com/user-attachments/assets/827a2ea4-1ddd-47e6-bafe-3649e230a8f3)

I change also `docker-compose` with `docker compose` as new standard! ;)